### PR TITLE
feat: add GitHub workflow to create/update major version tag

### DIFF
--- a/.github/workflows/major.yaml
+++ b/.github/workflows/major.yaml
@@ -1,0 +1,66 @@
+name: Tag Major Version
+
+on:
+  push:
+    tags: [v*.*.*]
+
+permissions:
+  contents: write
+
+jobs:
+  update-major-version-tag:
+    name: Update major version tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Get major version
+        id: major-version
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/}
+          MAJOR=${VERSION%%.*}
+          echo "sha=$(git rev-list -n 1 $VERSION)" >> $GITHUB_OUTPUT
+          echo "major=$MAJOR" >> $GITHUB_OUTPUT
+
+      - name: Find major tag
+        id: major-tag
+        uses: actions/github-script@v7
+        with:
+          result-encoding: string
+          script: |
+            try {
+              await github.rest.git.getRef({
+                  ...context.repo,
+                  ref: "tags/${{ steps.major-version.outputs.major }}"
+              });
+              return "1";
+            }
+            catch (err) {
+              if (err.status === 404)
+                  return "0";
+              throw err;
+            }
+
+      - name: Create major version tag
+        if: steps.major-tag.outputs.result == '0'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.git.createRef({
+              ...context.repo,
+              ref: "refs/tags/${{ steps.major-version.outputs.major }}",
+              sha: "${{ steps.major-version.outputs.sha }}"
+            })
+
+      - name: Move major version tag
+        if: steps.major-tag.outputs.result == '1'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.git.updateRef({
+              ...context.repo,
+              ref: "tags/${{ steps.major-version.outputs.major }}",
+              sha: "${{ steps.major-version.outputs.sha }}",
+              force: true
+            })

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Publish a version on Modrinth. Works for all Modrinth project types.
 ```yaml
 # …
 steps:
-  - uses: cloudnode-pro/modrinth-publish@2.0.0
+  - uses: cloudnode-pro/modrinth-publish@v2
     with:
       token: ${{ secrets.MODRINTH_TOKEN }}
       # … configure the action using inputs here
@@ -279,7 +279,7 @@ jobs:
         run: mvn -B clean package --file pom.xml
 
       - name: Upload to Modrinth
-        uses: cloudnode-pro/modrinth-publish@2.0.0
+        uses: cloudnode-pro/modrinth-publish@v2
         with:
           # Configure the action as needed. The following is an example.
           token: ${{ secrets.MODRINTH_TOKEN }}


### PR DESCRIPTION
This GitHub Action manages major version tags (e.g., `v2`).

When a new tag is pushed, the action updates the corresponding major version tag. If the major version tag already exists, it is moved to point to the newly pushed tag.

This ensures that the major version tag always references the latest release within that major version.