### PR TITLE
Update to Node.js v22 LTS

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org/
           cache: npm
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20
+FROM node:22
 WORKDIR /action
 COPY . .
 RUN npm install -g npm@latest


### PR DESCRIPTION
Updates the Docker image to use Node.js v22, which is the active LTS. Also switches to Node.js v22 for the action build CI.