### PR TITLE
Add support for specifying version ranges in `game-versions`

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ loaders: '["paper", "spigot", "bukkit"]'
 
 ### `game-versions` (required)
 
-List of supported Minecraft versions. You can use patterns like `1.21.x` and `26.1.x`.
+List of supported Minecraft versions. You can use patterns like `1.21.x` and `26.1.x` also a version range like `>=1.19` works.
 
 Format each version on a new line or use a JSON string array.
 
@@ -229,6 +229,10 @@ Format each version on a new line or use a JSON string array.
 
 ```yaml
 game-versions: 1.21.x
+```
+
+```yaml
+game-versions: >=1.19
 ```
 
 ```yaml

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,6 +139,17 @@ if (gameVersions.some(v => /^\d+\.\d+\.x$/i.test(v))) {
         );
         gameVersions.splice(index, 1, ...versions);
     }
+} else if (gameVersions.some(v => />=.*/i.test(v))) {
+    core.info("Fetching Mojang versions manifest…");
+    const versionsManifest = await VersionsManifest.fetch();
+    for (const version of gameVersions.filter(v => />=.*/i.test(v))) {
+        let index = versionsManifest.versions.indexOf(version.slice(2));
+        if (index === -1) {
+            core.warning(`Version ${version} not found in Mojang versions manifest, skipping…`);
+            continue;
+        }
+        gameVersions.splice(index, 1, ...versionsManifest.versions.splice(0, index + 1));
+    }
 }
 
 // Build the HTTP request


### PR DESCRIPTION
closes: #113

I tried to implement a simple solution, to only support version ranges equal or greater than like `>=1.19`