### PR TITLE
Use `semver` to expand version ranges for `game-versions`

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,9 +219,38 @@ loaders: '["paper", "spigot", "bukkit"]'
 
 ### `game-versions` (required)
 
-List of supported Minecraft versions. You can use patterns like `1.21.x` and `26.1.x`.
+List of supported Minecraft versions. You can specify both exact versions.
 
 Format each version on a new line or use a JSON string array.
+
+<details>
+<summary>Version ranges syntax</summary>
+
+> **Note**: Version ranges do not include snapshot versions.
+
+| Examples <small>(equivalent)</small>                     | Description                                                 | Result <small>(*latest version as of writing is 26.1.2*)</small> |
+|----------------------------------------------------------|-------------------------------------------------------------|------------------------------------------------------------------|
+| `1.21.x`, `=1.21`                                        | Patch versions of 1.21                                      | 1.21, 1.21.1, …, 1.21.11                                         |
+| `>=1.21.6`                                               | Versions equal or newer than 1.21.6                         | 1.21.6, 1.21.7, …, 26.1.2                                        |
+| `>1.21.6`                                                | Versions newer than 1.21.6                                  | 1.21.7, 1.21.8, …, 26.1.2                                        |
+| `>1.20.0`<sup>[*](#note-semver)</sup>                    | Versions newer than 1.20                                    | 1.20.1, 1.20.2, …, 26.1.2                                        |
+| `>1.20`, `>1.20.6`, `>=1.21`                             | Versions newer than any 1.20 version                        | 1.21, 1.21.1, …, 26.1.2                                          |
+| `>=1.20 < 26`, `1.20 - 26.0`<sup>[*](#note-semver)</sup> | Versions between 1.20 (inclusive) and 26 (exclusive)        | 1.20, 1.20.1, …, 1.21.11                                         |
+| `1.20 - 26`                                              | Versions between 1.20 and 26 (including all versions of 26) | 1.20, …, 26.1.1, 26.1.2                                          |
+
+> <a name="note-semver"></a><b>*</b> **Note**: In version ranges (only), versions with no patch version (3rd number),
+> e.g. `1.21` and `26.1`, are equivalent to `1.21.x` and `26.1.x` respectively. To specify the literal Mojang version
+> `1.21` or `26.1`, add `.0`, i.e. `1.21.0` and `26.1.0`.
+>
+> The same applies if the minor version (2nd number) is omitted, i.e. `26` is equivalent to `26.x`. To specify the first
+> version of 26, use `26.1.0` or `26.0`.
+>
+> See also: [SemVer Ranges](https://github.com/npm/node-semver?tab=readme-ov-file#ranges).
+>
+> <small>This is because Mojang does not follow standard [semantic versioning](https://semver.org/), but for simplicity
+> version ranges here are treated as such.</small>
+
+</details>
 
 <dl>
     <dt>Example</dt>

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ loaders: '["paper", "spigot", "bukkit"]'
 
 ### `game-versions` (required)
 
-List of supported Minecraft versions. You can specify both exact versions.
+List of supported Minecraft versions. You can specify both exact versions and version ranges.
 
 Format each version on a new line or use a JSON string array.
 

--- a/README.md
+++ b/README.md
@@ -230,13 +230,13 @@ Format each version on a new line or use a JSON string array.
 
 | Examples <small>(equivalent)</small>                     | Description                                                 | Result <small>(*latest version as of writing is 26.1.2*)</small> |
 |----------------------------------------------------------|-------------------------------------------------------------|------------------------------------------------------------------|
-| `1.21.x`, `=1.21`                                        | Patch versions of 1.21                                      | 1.21, 1.21.1, …, 1.21.11                                         |
-| `>=1.21.6`                                               | Versions equal or newer than 1.21.6                         | 1.21.6, 1.21.7, …, 26.1.2                                        |
-| `>1.21.6`                                                | Versions newer than 1.21.6                                  | 1.21.7, 1.21.8, …, 26.1.2                                        |
-| `>1.20.0`<sup>[*](#note-semver)</sup>                    | Versions newer than 1.20                                    | 1.20.1, 1.20.2, …, 26.1.2                                        |
-| `>1.20`, `>1.20.6`, `>=1.21`                             | Versions newer than any 1.20 version                        | 1.21, 1.21.1, …, 26.1.2                                          |
-| `>=1.20 < 26`, `1.20 - 26.0`<sup>[*](#note-semver)</sup> | Versions between 1.20 (inclusive) and 26 (exclusive)        | 1.20, 1.20.1, …, 1.21.11                                         |
-| `1.20 - 26`                                              | Versions between 1.20 and 26 (including all versions of 26) | 1.20, …, 26.1.1, 26.1.2                                          |
+| `1.21.x`, `=1.21`                                        | Patch versions of 1.21                                      | `1.21`, `1.21.1`, …, `1.21.11`                                   |
+| `>=1.21.6`                                               | Versions equal or newer than 1.21.6                         | `1.21.6`, `1.21.7`, …, `26.1.2`                                  |
+| `>1.21.6`                                                | Versions newer than 1.21.6                                  | `1.21.7`, `1.21.8`, …, `26.1.2`                                  |
+| `>1.20.0`<sup>[*](#note-semver)</sup>                    | Versions newer than 1.20                                    | `1.20.1`, `1.20.2`, …, `26.1.2`                                  |
+| `>1.20`, `>1.20.6`, `>=1.21`                             | Versions newer than any 1.20 version                        | `1.21`, `1.21.1`, …, `26.1.2`                                    |
+| `>=1.20 < 26`, `1.20 - 26.0`<sup>[*](#note-semver)</sup> | Versions between 1.20 (inclusive) and 26 (exclusive)        | `1.20`, `1.20.1`, …, `1.21.11`                                   |
+| `1.20 - 26`                                              | Versions between 1.20 and 26 (including all versions of 26) | `1.20`, …, `26.1.1`, `26.1.2`                                    |
 
 > <a name="note-semver"></a><b>*</b> **Note**: In version ranges (only), versions with no patch version (3rd number),
 > e.g. `1.21` and `26.1`, are equivalent to `1.21.x` and `26.1.x` respectively. To specify the literal Mojang version

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,10 +5,12 @@
   "packages": {
     "": {
       "dependencies": {
-        "@actions/core": "^3.0.1"
+        "@actions/core": "^3.0.1",
+        "semver": "^7.8.0"
       },
       "devDependencies": {
         "@types/node": "^24.12.3",
+        "@types/semver": "^7.7.1",
         "typescript": "^6.0.3"
       }
     },
@@ -55,6 +57,25 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/tunnel": {

--- a/package.json
+++ b/package.json
@@ -5,10 +5,12 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@actions/core": "^3.0.1"
+    "@actions/core": "^3.0.1",
+    "semver": "^7.8.0"
   },
   "devDependencies": {
     "@types/node": "^24.12.3",
+    "@types/semver": "^7.7.1",
     "typescript": "^6.0.3"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import * as core from "@actions/core";
+import * as semver from "semver";
 import fs from "node:fs/promises";
 import path from "node:path";
 import {VersionsManifest} from "./VersionsManifest.js";
@@ -127,17 +128,36 @@ if (primaryFileName !== null && !files.some(f => f.name === primaryFileName)) {
     process.exit(1);
 }
 
-// Expand versions such as 1.21.x
-if (gameVersions.some(v => /^\d+\.\d+\.x$/i.test(v))) {
+// Interpret version ranges such as 1.21.x || >= 26.1
+const versionRanges = gameVersions
+    .reduce<[index: number, range: string][]>((acc, v, i) => {
+        // exclude exact versions (non-ranges)
+        // coerce(1.21) → 1.21.0; this is checked because Mojang doesn’t actually follow SemVer (elides .0 patch)
+        const coerced = semver.coerce(v, {includePrerelease: true})?.version;
+        if (coerced === v || coerced === v + ".0") {
+            return acc;
+        }
+
+        const r = semver.validRange(v);
+        if (r !== null) {
+            acc.push([i, r]);
+        }
+        return acc;
+    }, []);
+
+if (versionRanges.length > 0) {
     core.info("Fetching Mojang versions manifest…");
     const versionsManifest = await VersionsManifest.fetch();
-    for (const version of gameVersions.filter(v => /^\d+\.\d+\.x$/i.test(v))) {
-        const index = gameVersions.indexOf(version);
-        const baseVersion = version.slice(0, -2);
-        const versions = versionsManifest.versions.filter(v =>
-            v === baseVersion || v.startsWith(baseVersion + ".")
-        );
-        gameVersions.splice(index, 1, ...versions);
+
+    for (const [i] of versionRanges.toReversed()) {
+        gameVersions.splice(i, 1);
+    }
+
+    for (const v of versionsManifest.versions) {
+        const coerced = semver.coerce(v);
+        if (coerced !== null && versionRanges.some(([, r]) => semver.satisfies(coerced, r))) {
+            gameVersions.push(v);
+        }
     }
 }
 


### PR DESCRIPTION
Adds interpretation for more complex version ranges using `>=`, `||`, `<`, `-`, etc., using [`semver`](https://github.com/npm/node-semver)’s functionality for interpreting [ranges](https://github.com/npm/node-semver#ranges).

Since Mojang versions are not SemVer but still similar to it, some additional checks are done:

- Versions like 1.21 and 26.1 are treated as equivalents in semver to 1.21.0 and 26.1.0 (Mojang elides the `.0`).
- Snapshots and pre-releases are not expanded in ranges (which is consistent with the existing behaviour of the action). The action still allows arbitrary inputs for `gameVersions`, which means you can manually specify snapshots/pre-releases, but crucially, anything that's not a range, also falls under this category, such as exact versions like `1.21.11`, `26.1.2`, etc. However, the `semver` library is happy to treat `1.21.11` as a range (of a single version), so an additional check (`coerced === v`) discriminates them as non-ranges.

Backwards-compatible with the `1.21.x` format used previously, as the `semver` library interprets it correctly.